### PR TITLE
Updated paged utilities

### DIFF
--- a/Pinja.NetCore.WebApi.Util/Paged/Paged.cs
+++ b/Pinja.NetCore.WebApi.Util/Paged/Paged.cs
@@ -18,19 +18,24 @@ namespace Pinja.NetCore.WebApi.Util.Paged
         }
 
         public IEnumerable<T> Data { get; set; } = new List<T>();
-        public int ResultCount { get; set; }
-        public int PageCount { get; set; }
+        public int? ResultCount { get; set; }
+        public int? PageCount { get; set; }
         public int PageSize { get; set; }
 
-        public static Paged<T> FromQuery(IQueryable<T> data, int page, int pageSize = 50)
+        public static Paged<T> FromQuery(IQueryable<T> data, int page, int pageSize = 50, bool countTotalPages = true)
         {
             var result = data.Skip(page * pageSize).Take(pageSize + 1).ToList();
 
-            var dataCount = data.Count();
+            var dataCount = countTotalPages ? data.Count() : default;
 
             var pages = (dataCount + pageSize - 1) / pageSize;
 
             return new Paged<T>(result.Take(pageSize), dataCount, pages, pageSize);
+        }
+
+        public static Paged<T> FromEnumerable(IEnumerable<T> data)
+        {
+            return new Paged<T>(data, default, default, data.Count());
         }
     }
 }

--- a/Pinja.NetCore.WebApi.Util/Paged/PagedUtils.cs
+++ b/Pinja.NetCore.WebApi.Util/Paged/PagedUtils.cs
@@ -1,0 +1,12 @@
+using System.Linq;
+
+namespace Pinja.NetCore.WebApi.Util.Paged
+{
+    public static class PagedUtils
+    {
+        public static IQueryable<T> Paginate<T>(this IQueryable<T> data, int page, int pageSize = 50)
+        {
+            return data.Skip(page * pageSize).Take(pageSize + 1);
+        }
+    }
+}


### PR DESCRIPTION
- Sometimes you need more control how query is implemented with pagination. For this reason `Paginate` extension is added.
- In expensive queries couting total pages / total results is very expensive, added option to ignore it.